### PR TITLE
Add attempts to reconnect to master for any kind of error

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ hosts = [
 redis = Redic::Sentinels.new hosts: hosts, 
                              master_name: 'mymaster', 
                              db: 1, # optional (default: 0)
-                             password: 'pass' # optional
+                             password: 'pass', # optional
+                             max_retries: 5 # optional (default: 3): Number of attempts to reconnect to master
 
 redis.call 'PING' # => 'PONG'
 ```

--- a/lib/redic/sentinels.rb
+++ b/lib/redic/sentinels.rb
@@ -67,7 +67,9 @@ class Redic
     attr_reader :redis
 
     def forward
-      yield
+      yield.tap do |result|
+        @retry_attempts = 0
+      end
     rescue => ex
       @retry_attempts ||= 0
       if @retry_attempts < @max_retries


### PR DESCRIPTION
When the master changed, there wasn't any reconnection to the new one, so every time someone tried to write on the slave it would get a RuntimeError: "READONLY You can't write against a read only slave.". This should solve that problem.